### PR TITLE
Move .clang-format-ignore

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,2 +1,2 @@
 # Contains import code from homuler/MediaPipeUnityPlugin project
-Assets/Scripts/Mediapipe/*
+Assets/Scripts/Mediapipe/.*


### PR DESCRIPTION
Move `.clang-format-ignore` file to the root of the project and update wildcard matching.