### PR TITLE
Support eye blinking

### DIFF
--- a/Assets/Scripts/Animator/FaceLandmarksRecognizer.cs
+++ b/Assets/Scripts/Animator/FaceLandmarksRecognizer.cs
@@ -23,6 +23,21 @@ using UnityEngine;
 
 namespace SeedUnityVRKit {
   public class FaceLandmarksRecognizer {
+    // Source of truth:
+    // https://github.com/tensorflow/tfjs-models/blob/master/face-landmarks-detection/src/tfjs/constants.ts
+    private static readonly int[] _leftEyeIndex =
+        new int[] {// Lower contour.
+                   33, 7, 163, 144, 145, 153, 154, 155, 133,
+                   // upper contour (excluding corners).
+                   246, 161, 160, 159, 158, 157, 173
+        };
+    private static readonly int[] _rightEyeIndex =
+        new int[] {// Lower contour.
+                   263, 249, 390, 373, 374, 380, 381, 382, 362,
+                   // Upper contour (excluding corners).
+                   466, 388, 387, 386, 385, 384, 398
+        };
+    private static readonly float _eyeOpenThreshold = 0.33f;
     /// <summary>
     /// Constant canonical face model from
     /// https://github.com/google/mediapipe/blob/master/mediapipe/modules/face_geometry/data/canonical_face_model.obj
@@ -86,6 +101,12 @@ namespace SeedUnityVRKit {
       faceLandmarks.FaceRotation = new Vector3(yaw, roll, pitch);
 
       faceLandmarks.MouthAspectRatio = ComputeMouth(faceMesh);
+      var leftEyeAspectRatio = ComputeEye(faceMesh, _leftEyeIndex);
+      var rightEyeAspectRatio = ComputeEye(faceMesh, _rightEyeIndex);
+      faceLandmarks.LeftEyeShape =
+          leftEyeAspectRatio > _eyeOpenThreshold ? EyeShape.Open : EyeShape.Close;
+      faceLandmarks.RightEyeShape =
+          rightEyeAspectRatio > _eyeOpenThreshold ? EyeShape.Open : EyeShape.Close;
       return faceLandmarks;
     }
 
@@ -106,6 +127,14 @@ namespace SeedUnityVRKit {
       var mouthDistance = (float)(p1 - p5).magnitude;
       mar /= (float)(2 * mouthDistance + 1e-6);
       return mar;
+    }
+
+    private static float ComputeEye(IList<Vector2> faceMesh, int[] index) {
+      float total = 0;
+      for (int i = 1; i <= 7; i++) {
+        total += (faceMesh[index[i]] - faceMesh[index[8 + i]]).magnitude;
+      }
+      return total / (faceMesh[index[0]] - faceMesh[index[8]]).magnitude / 7;
     }
   }
 }

--- a/Assets/Scripts/Animator/UpperBodyAnimator.cs
+++ b/Assets/Scripts/Animator/UpperBodyAnimator.cs
@@ -19,8 +19,6 @@ using UnityEngine;
 namespace SeedUnityVRKit {
   // <summary>An animator to visualize upper body and face.</summary>
   public class UpperBodyAnimator : MonoBehaviour {
-    [Tooltip("Reference to MTH_DEF game object in UnityChan model.")]
-    public SkinnedMeshRenderer MthDefRef;
     [Tooltip("Max rotation angle in degree.")]
     [Range(0, 45f)]
     public float MaxRotationThreshold = 40f;
@@ -28,6 +26,7 @@ namespace SeedUnityVRKit {
     public float ScreenWidth = 1920;
     [Tooltip("Screen height used as to scale the recognized normalized landmarks.")]
     public float ScreenHeight = 1080;
+    private const string MthDefConst = "MTH_DEF";
     /// <summary>The neck joint to control head rotation.</summary>
     private Transform _neck;
     /// <summary>Face landmark recognizer.</summary>
@@ -36,6 +35,7 @@ namespace SeedUnityVRKit {
     /// <summary>Pose landmark recognizer.</summary>
     private PoseLandmarksRecognizer _poseLandmarksRecognizer;
     private NormalizedLandmarkList _poseLandmarkList;
+    private SkinnedMeshRenderer _mouthMeshRenderer;
 
     private Joint[] _joints = new Joint[Landmarks.Total];
 
@@ -46,6 +46,7 @@ namespace SeedUnityVRKit {
       _neck = anim.GetBoneTransform(HumanBodyBones.Neck);
       _faceLandmarksRecognizer = new FaceLandmarksRecognizer(ScreenWidth, ScreenHeight);
       _poseLandmarksRecognizer = new PoseLandmarksRecognizer(ScreenWidth, ScreenHeight);
+      _mouthMeshRenderer = GameObject.Find(MthDefConst).GetComponent<SkinnedMeshRenderer>();
     }
 
     private void setupJoints(Animator anim) {
@@ -110,7 +111,7 @@ namespace SeedUnityVRKit {
     }
 
     private void SetMouth(float ratio) {
-      MthDefRef.SetBlendShapeWeight(2, ratio * 100);
+      _mouthMeshRenderer.SetBlendShapeWeight(2, ratio * 100);
     }
 
     public void OnFaceLandmarksOutput(NormalizedLandmarkList list) {

--- a/Assets/Scripts/Animator/UpperBodyAnimator.cs
+++ b/Assets/Scripts/Animator/UpperBodyAnimator.cs
@@ -27,6 +27,8 @@ namespace SeedUnityVRKit {
     [Tooltip("Screen height used as to scale the recognized normalized landmarks.")]
     public float ScreenHeight = 1080;
     private const string MthDefConst = "MTH_DEF";
+    private const string EyeDefConst = "EYE_DEF";
+    private const string ElDefConst = "EL_DEF";
     /// <summary>The neck joint to control head rotation.</summary>
     private Transform _neck;
     /// <summary>Face landmark recognizer.</summary>
@@ -36,6 +38,8 @@ namespace SeedUnityVRKit {
     private PoseLandmarksRecognizer _poseLandmarksRecognizer;
     private NormalizedLandmarkList _poseLandmarkList;
     private SkinnedMeshRenderer _mouthMeshRenderer;
+    private SkinnedMeshRenderer _eyeMeshRenderer;
+    private SkinnedMeshRenderer _elMeshRenderer;
 
     private Joint[] _joints = new Joint[Landmarks.Total];
 
@@ -47,6 +51,8 @@ namespace SeedUnityVRKit {
       _faceLandmarksRecognizer = new FaceLandmarksRecognizer(ScreenWidth, ScreenHeight);
       _poseLandmarksRecognizer = new PoseLandmarksRecognizer(ScreenWidth, ScreenHeight);
       _mouthMeshRenderer = GameObject.Find(MthDefConst).GetComponent<SkinnedMeshRenderer>();
+      _eyeMeshRenderer = GameObject.Find(EyeDefConst).GetComponent<SkinnedMeshRenderer>();
+      _elMeshRenderer = GameObject.Find(ElDefConst).GetComponent<SkinnedMeshRenderer>();
     }
 
     private void setupJoints(Animator anim) {
@@ -94,6 +100,8 @@ namespace SeedUnityVRKit {
         FaceLandmarks faceLandmarks = _faceLandmarksRecognizer.recognize(_faceLandmarkList);
         _neck.localEulerAngles = ClampFaceRotation(faceLandmarks.FaceRotation);
         SetMouth(faceLandmarks.MouthAspectRatio);
+        SetEye(faceLandmarks.LeftEyeShape == EyeShape.Close &&
+               faceLandmarks.RightEyeShape == EyeShape.Close);
       }
 
       if (_poseLandmarkList != null) {
@@ -112,6 +120,16 @@ namespace SeedUnityVRKit {
 
     private void SetMouth(float ratio) {
       _mouthMeshRenderer.SetBlendShapeWeight(2, ratio * 100);
+    }
+
+    private void SetEye(bool close) {
+      if (close) {
+        _eyeMeshRenderer.SetBlendShapeWeight(6, 100);
+        _elMeshRenderer.SetBlendShapeWeight(6, 100);
+      } else {
+        _eyeMeshRenderer.SetBlendShapeWeight(6, 0);
+        _elMeshRenderer.SetBlendShapeWeight(6, 0);
+      }
     }
 
     public void OnFaceLandmarksOutput(NormalizedLandmarkList list) {


### PR DESCRIPTION
Add support to recognize eye aspect ratio to support eye blinking.

The EAR (eye aspect ratio) is calculated by taking measurement of the contour to compute average open height, and compare to the width of the eye. Based on some tests, common range is around [0.25, 0.4], therefore, a threshold of 0.33 is used to determine if the eye is open or close. 

Close #21.
