### PR TITLE
Fix head rotation (attempt 2)

### DIFF
--- a/Assets/Scripts/Animator/FaceLandmarks.cs
+++ b/Assets/Scripts/Animator/FaceLandmarks.cs
@@ -30,7 +30,7 @@ namespace SeedUnityVRKit {
     public float MouthAspectRatio { get; set; }
     public EyeShape LeftEyeShape { get; set; }
     public EyeShape RightEyeShape { get; set; }
-    public Vector3 FaceRotation { get; set; }
+    public Quaternion FaceRotation { get; set; }
     public MouthShape MouthShape {
       get {
         if (MouthAspectRatio < 0.1) {

--- a/Assets/Scripts/Animator/FaceLandmarksRecognizer.cs
+++ b/Assets/Scripts/Animator/FaceLandmarksRecognizer.cs
@@ -95,10 +95,9 @@ namespace SeedUnityVRKit {
       solvePnP(_screenWidth, _screenHeight, _face3DPoints, pnpArray, null, null, _rotationVector,
                _translationVector, useExtrinsicGuess);
 
-      var roll = (float)(-Degree(_rotationVector[0]));
-      var yaw = (float)(-Degree(_rotationVector[1]) + 180);
-      var pitch = (float)(-Degree(_rotationVector[2]));
-      faceLandmarks.FaceRotation = new Vector3(yaw, roll, pitch);
+      Vector3 axis = new Vector3(_rotationVector[0], _rotationVector[1], _rotationVector[2]);
+      float theta = (float)(axis.magnitude * 180 / Math.PI);
+      faceLandmarks.FaceRotation = Quaternion.AngleAxis(theta, axis);
 
       faceLandmarks.MouthAspectRatio = ComputeMouth(faceMesh);
       var leftEyeAspectRatio = ComputeEye(faceMesh, _leftEyeIndex);

--- a/Assets/Scripts/Animator/UpperBodyAnimator.cs
+++ b/Assets/Scripts/Animator/UpperBodyAnimator.cs
@@ -29,6 +29,7 @@ namespace SeedUnityVRKit {
     private const string MthDefConst = "MTH_DEF";
     private const string EyeDefConst = "EYE_DEF";
     private const string ElDefConst = "EL_DEF";
+    private static readonly Quaternion _neckInitRotation = Quaternion.Euler(0, -90, -90);
     /// <summary>The neck joint to control head rotation.</summary>
     private Transform _neck;
     /// <summary>Face landmark recognizer.</summary>
@@ -98,7 +99,7 @@ namespace SeedUnityVRKit {
     void LateUpdate() {
       if (_faceLandmarkList != null) {
         FaceLandmarks faceLandmarks = _faceLandmarksRecognizer.recognize(_faceLandmarkList);
-        _neck.localEulerAngles = ClampFaceRotation(faceLandmarks.FaceRotation);
+        _neck.rotation = faceLandmarks.FaceRotation * _neckInitRotation;
         SetMouth(faceLandmarks.MouthAspectRatio);
         SetEye(faceLandmarks.LeftEyeShape == EyeShape.Close &&
                faceLandmarks.RightEyeShape == EyeShape.Close);
@@ -110,12 +111,6 @@ namespace SeedUnityVRKit {
           _joints[poseLandmark.Id].SetRotation(poseLandmark.Rotation);
         }
       }
-    }
-
-    private Vector3 ClampFaceRotation(Vector3 rotation) {
-      return new Vector3(rotation.x,  // Do not clamp x
-                         Mathf.Clamp(rotation.y, -MaxRotationThreshold, MaxRotationThreshold),
-                         Mathf.Clamp(rotation.z, -MaxRotationThreshold, MaxRotationThreshold));
     }
 
     private void SetMouth(float ratio) {


### PR DESCRIPTION
Change FaceRotation from Euler angle to Quaternion. It appears to fix the issue.

Previous PR (https://github.com/SeedV/SeedUnityVRKit/pull/24) did not fix the issue. The recognition still sometimes get the movement direction (up/down, left/right) inverted. It's hard to 100% repro on each run.

I suspect the previous implementation has problems specific to Euler angles, like gimbal lock.

Side effect: The clamping of face rotation is removed, however, it doesn't seem to be necessary from my current testing, but we can add it back if there's a requirement to clamp at a max angle.

References:
https://answers.unity.com/questions/1266985/convert-rotation-vector-or-matrix-to-quaternion.html
https://github.com/yuenshome/yuenshome.github.io/issues/9

Fix #19 