### PR TITLE
Keep track of FPS throughput at different key moments.

### DIFF
--- a/Assets/Scenes/VTuber.unity
+++ b/Assets/Scenes/VTuber.unity
@@ -476,6 +476,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  systemStats: {fileID: 1625187022}
 --- !u!114 &870755769
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -556,6 +557,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1625187021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1625187023}
+  - component: {fileID: 1625187022}
+  m_Layer: 0
+  m_Name: SystemStats
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1625187022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1625187021}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f582e51d2f14443cb654aea2e579fc4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1625187023
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1625187021}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1642654471
 GameObject:

--- a/Assets/Scripts/Tracker/BaseTracker.cs
+++ b/Assets/Scripts/Tracker/BaseTracker.cs
@@ -23,6 +23,7 @@ using UnityEngine;
 namespace SeedUnityVRKit {
 
   public abstract class BaseTracker : MonoBehaviour {
+    public SystemStats systemStats;
     private const string _tag = nameof(BaseTracker);
     public enum InferenceMode {
       CPU,
@@ -92,7 +93,9 @@ namespace SeedUnityVRKit {
           continue;
         }
         textureFrame.ReadTextureFromOnCPU(image);
+        systemStats?.IncrementFrameReadTexture();
         _graphRunner.AddTextureFrameToInputStream(textureFrame);
+        systemStats?.IncrementFrameAddToInputStream();
         yield return null;
       }
     }

--- a/Assets/Scripts/Tracker/SystemStats.cs
+++ b/Assets/Scripts/Tracker/SystemStats.cs
@@ -42,7 +42,7 @@ namespace SeedUnityVRKit {
     private Queue<StatsData> _statsQueue = new Queue<StatsData>();
 
     public IEnumerator Start() {
-      Debug.Log($"SystemStats: Waiting for {_delaySeconds} seconds to stablize.");
+      Debug.Log($"SystemStats: Waiting for {_delaySeconds} seconds to stabilize.");
       yield return new WaitForSeconds(_delaySeconds);
       Debug.Log("SystemStats: Counters started");
       while (true) {

--- a/Assets/Scripts/Tracker/SystemStats.cs
+++ b/Assets/Scripts/Tracker/SystemStats.cs
@@ -1,0 +1,91 @@
+// Copyright 2021-2022 The SeedV Lab.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SeedUnityVRKit {
+  class StatsData {
+    public int Id { get; set; }
+    public int FrameProcessed { get; set; }
+    public int FrameRendered { get; set; }
+    public int FrameReadTexture { get; set; }
+    public int FrameAddToInputStream { get; set; }
+    public override string ToString() {
+      return $"SystemStats: [{Id}] FrameReadTexture: {FrameReadTexture} " +
+             $"FrameAddToInputStream: {FrameAddToInputStream} FrameProcessed: {FrameProcessed} " +
+             $"FrameRendered: {FrameRendered}";
+    }
+  }
+
+  public class SystemStats : MonoBehaviour {
+    private const int _maxBuffer = 20;
+    private const int _delaySeconds = 3;
+    private const int _sampleInterval = 1;
+    private int _frameIdCounter = 0;
+    private int _frameProcessedCounter = 0;
+    private int _frameRenderedCounter = 0;
+    private int _frameReadTextureCounter = 0;
+    private int _frameAddToInputStreamCounter = 0;
+    private Queue<StatsData> _statsQueue = new Queue<StatsData>();
+
+    public IEnumerator Start() {
+      Debug.Log($"SystemStats: Waiting for {_delaySeconds} seconds to stablize.");
+      yield return new WaitForSeconds(_delaySeconds);
+      Debug.Log("SystemStats: Counters started");
+      while (true) {
+        _frameProcessedCounter = 0;
+        _frameRenderedCounter = 0;
+        _frameReadTextureCounter = 0;
+        _frameAddToInputStreamCounter = 0;
+        yield return new WaitForSeconds(_sampleInterval);
+        StatsData data = new StatsData {
+          Id = _frameIdCounter,
+          FrameProcessed = _frameProcessedCounter,
+          FrameRendered = _frameRenderedCounter,
+          FrameAddToInputStream = _frameAddToInputStreamCounter,
+          FrameReadTexture = _frameReadTextureCounter,
+        };
+        _statsQueue.Enqueue(data);
+        if (_statsQueue.Count > _maxBuffer) {
+          _statsQueue.Dequeue();
+        }
+        _frameIdCounter++;
+      }
+    }
+
+    public void OnApplicationQuit() {
+      foreach (var stats in _statsQueue) {
+        Debug.Log(stats.ToString());
+      }
+    }
+
+    public void IncrementFrameProcessed() {
+      _frameProcessedCounter++;
+    }
+
+    public void IncrementFrameRendered() {
+      _frameRenderedCounter++;
+    }
+
+    public void IncrementFrameReadTexture() {
+      _frameReadTextureCounter++;
+    }
+
+    public void IncrementFrameAddToInputStream() {
+      _frameAddToInputStreamCounter++;
+    }
+  }
+}

--- a/Assets/Scripts/Tracker/SystemStats.cs.meta
+++ b/Assets/Scripts/Tracker/SystemStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f582e51d2f14443cb654aea2e579fc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds SystemStats class to keep track of four key frame rates:
- The frame rate to read from camera output texture into internal CPU buffer
- The frame rate to send frames to mediapipe graph
- The frame rate when the holistic model returns results (async callbacks)
- The frame rate when the Update() method kicks in and push the result to UnityEvents

Usage:
After starting the scene, there will be 3 seconds delay to start getting FPS data
After ending the scene, last 20 frames will be printed to debug console, like:

```
SystemStats: [0] FrameReadTexture: 24 FrameAddToInputStream: 24 FrameProcessed: 24 FrameRendered: 24
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [1] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [2] FrameReadTexture: 24 FrameAddToInputStream: 24 FrameProcessed: 24 FrameRendered: 24
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [3] FrameReadTexture: 26 FrameAddToInputStream: 26 FrameProcessed: 26 FrameRendered: 26
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [4] FrameReadTexture: 24 FrameAddToInputStream: 24 FrameProcessed: 24 FrameRendered: 24
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [5] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [6] FrameReadTexture: 24 FrameAddToInputStream: 24 FrameProcessed: 24 FrameRendered: 24
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [7] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [8] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [9] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [10] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [11] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 26 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [12] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)

SystemStats: [13] FrameReadTexture: 25 FrameAddToInputStream: 25 FrameProcessed: 25 FrameRendered: 25
UnityEngine.Debug:Log (object)
SeedUnityVRKit.SystemStats:OnApplicationQuit () (at Assets/Scripts/Tracker/SystemStats.cs:69)
```