### PR TITLE
Rebind hand animation control to HolisticTracker

### DIFF
--- a/Assets/Scenes/VTuber.unity
+++ b/Assets/Scenes/VTuber.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -290,6 +290,17 @@ RectTransform:
   m_AnchoredPosition: {x: -50, y: -10}
   m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &806519408 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 866042038, guid: 1639ff504c5034ce2a726caf017d9bcf, type: 3}
+  m_PrefabInstance: {fileID: 2958611280621633103}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4d3ebea03ea74803935ae87b3b2aed0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &870755766
 GameObject:
   m_ObjectHideFlags: 0
@@ -345,6 +356,8 @@ MonoBehaviour:
   _rotation: 0
   _modelAnimator: {fileID: 364035617}
   _holisticAnnotationController: {fileID: 745539341}
+  LeftHandLandmarksController: {fileID: 806519408}
+  RightHandLandmarksController: {fileID: 2073231105}
 --- !u!114 &870755769
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -956,6 +969,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2073231105 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 468427542, guid: 1639ff504c5034ce2a726caf017d9bcf, type: 3}
+  m_PrefabInstance: {fileID: 2958611280621633103}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4d3ebea03ea74803935ae87b3b2aed0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2958611280621633103
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Animator/HandLandmarksController.cs
+++ b/Assets/Scripts/Animator/HandLandmarksController.cs
@@ -29,6 +29,7 @@ namespace SeedUnityVRKit {
     public HandType handType;
     public int ScreenWidth;
     public int ScreenHeight;
+    public NormalizedLandmarkList HandLandmarkList { private get; set; }
 
     // Total number of landmarks in HandPose model, per hand.
     private const int _landmarksNum = 21;
@@ -57,6 +58,18 @@ namespace SeedUnityVRKit {
     void Update() {
       transform.position = _target.transform.position;
       _target.rotation = ComputeWristRotation();
+
+      if (HandLandmarkList != null) {
+        NormalizedLandmark landmark0 = HandLandmarkList.Landmark[0];
+        NormalizedLandmark landmark1 = HandLandmarkList.Landmark[1];
+        var s = _modelThumbLength / (ToVector(landmark1) - ToVector(landmark0)).magnitude;
+        var scale = new Vector3(s * _screenRatio, s, s * _screenRatio);
+        for (int i = 1; i < HandLandmarkList.Landmark.Count; i++) {
+          NormalizedLandmark landmark = HandLandmarkList.Landmark[i];
+          Vector3 tip = Vector3.Scale(ToVector(landmark) - ToVector(landmark0), scale);
+          _handLandmarks[i].transform.localPosition = tip;
+        }
+      }
     }
 
     void OnDrawGizmos() {
@@ -71,20 +84,6 @@ namespace SeedUnityVRKit {
       foreach (var handLandmark in _handLandmarks) {
         if (handLandmark != null)
           Gizmos.DrawSphere(handLandmark.transform.position, 0.005f);
-      }
-    }
-
-    public void OnHandLandmarksOutput(NormalizedLandmarkList landmarkList) {
-      if (landmarkList != null) {
-        NormalizedLandmark landmark0 = landmarkList.Landmark[0];
-        NormalizedLandmark landmark1 = landmarkList.Landmark[1];
-        var s = _modelThumbLength / (ToVector(landmark1) - ToVector(landmark0)).magnitude;
-        var scale = new Vector3(s * _screenRatio, s, s * _screenRatio);
-        for (int i = 1; i < landmarkList.Landmark.Count; i++) {
-          NormalizedLandmark landmark = landmarkList.Landmark[i];
-          Vector3 tip = Vector3.Scale(ToVector(landmark) - ToVector(landmark0), scale);
-          _handLandmarks[i].transform.localPosition = tip;
-        }
       }
     }
 

--- a/Assets/Scripts/Tracker/HolisticTracker.cs
+++ b/Assets/Scripts/Tracker/HolisticTracker.cs
@@ -27,6 +27,12 @@ namespace SeedUnityVRKit {
     [SerializeField]
     private HolisticLandmarkListAnnotationController _holisticAnnotationController;
 
+    [SerializeField]
+    private HandLandmarksController LeftHandLandmarksController;
+
+    [SerializeField]
+    private HandLandmarksController RightHandLandmarksController;
+
     public override void AddEventHandler() {
       _graphRunner.OnFaceLandmarksOutput += OnFaceLandmarksOutput;
       _graphRunner.OnFaceLandmarksOutput += _modelAnimator.OnFaceLandmarksOutput;
@@ -48,11 +54,13 @@ namespace SeedUnityVRKit {
 
     private void OnLeftHandLandmarksOutput(object stream,
                                            OutputEventArgs<NormalizedLandmarkList> eventArgs) {
+      LeftHandLandmarksController.HandLandmarkList = eventArgs.value;
       _holisticAnnotationController.DrawLeftHandLandmarkListLater(eventArgs.value);
     }
 
     private void OnRightHandLandmarksOutput(object stream,
                                             OutputEventArgs<NormalizedLandmarkList> eventArgs) {
+      RightHandLandmarksController.HandLandmarkList = eventArgs.value;
       _holisticAnnotationController.DrawRightHandLandmarkListLater(eventArgs.value);
     }
   }


### PR DESCRIPTION
This change adds back the left and right hand's landmark outputs to their corresponding controllers. #44 reverted this binding as a part to rollback the previous change.

Scene is changed to link the game object of wrists to the controller.

<img width="242" alt="Screen Shot 2022-06-18 at 12 01 28 AM" src="https://user-images.githubusercontent.com/2952735/174426851-f1f7607b-6a23-406f-abbd-69066d0ba8ff.png">

