### PR TITLE
Improve univariant Kalman Filter

### DIFF
--- a/Assets/Scripts/Animator/KalmanFilter.cs
+++ b/Assets/Scripts/Animator/KalmanFilter.cs
@@ -8,28 +8,32 @@ namespace SeedUnityVRKit {
   // A good interactive tutorial for beginners about Kalman filter is
   // https://simondlevy.academic.wlu.edu/kalman-tutorial/.
   //
-  // This is a scalar version, only models one variable (position).
+  // This is a one-dimensional version, only models one variable (position).
   // </summary>
   public class KalmanFilter {
-    // Process noise models noise to an "ideal" estimated state transition. The larger the
-    // value, the less accurate the new estimation is based on law of physics.
+    // Variance of how confident the new estimate follows the prediction.
+    // A prediction assumed an ideal state transition following the law of physics.
     private readonly float _q;
-    // Measure noise models noise in the measurement process. The larger the value is, the
-    // less accurate the measure is.
+    // Variance of how confident the measurement is. The larger this value, the less confident the
+    // measurement is.
     private readonly float _r;
-    // Prediction error is used to update the Kalman gain. It is recursively updated from its
-    // last value with Kalman gain.
-    // p_k = (1 – g_k) * p_(k−1)
+    // Variance of how confident the current estimation is.
+    // Predict:
+    //   pPred = p + q
+    // Update:
+    //   p = (1 - K) * pPred
     private float _p = 0.1f;
-    // Prediction is recursively updated with
-    // x_k = x_(k-1) + g_k * (z_k - x_(k-1))
-    // It presents the most likely position of the object at given observation.
+    // The estimated position of the object.
+    // Predict:
+    //   xPred = x
+    // Update:
+    //   x = xPred + K * (measurement - xPred)
     private Vector3 _x;
-    // The Kalman gain is used to trade-off between estimated state from last time and current
-    // measurement. Kalman gain is 0 means the estimated state is correct. Kalman gain is 1 means
-    // the measured value (observation) is correct. It can be updated using prediction errors from
-    // last state.
-    // g_k = (p_(k-1) + q) / (p_(k-1) + q + r)
+    // The Kalman gain is a scale factor between the predicted location and measurement.
+    // Kalman gain is 0 means the predicted location is correct. Kalman gain is 1 means
+    // the measured value (observation) is correct.
+    // Update:
+    //   K = pPred / (pPred + r)
     private float _k;
 
     public KalmanFilter(float q, float r) {
@@ -38,10 +42,10 @@ namespace SeedUnityVRKit {
     }
 
     public Vector3 Update(Vector3 measurement) {
-      _k = (_p + _q) / (_p + _q + _r);
-      _p = _r * (_p + _q) / (_r + _p + _q);
-      Vector3 ret = _x + (measurement - _x) * _k;
-      return _x = ret;
+      var pPred = _p + _q;
+      _k = pPred / (pPred + _r);
+      _p = (1 - _k) * pPred;
+      return _x = _x + (measurement - _x) * _k;
     }
 
     public void Reset() {

--- a/Assets/Scripts/Animator/KalmanFilter.cs
+++ b/Assets/Scripts/Animator/KalmanFilter.cs
@@ -41,6 +41,16 @@ namespace SeedUnityVRKit {
       _r = r;
     }
 
+    // <summary>
+    // Updates the internal estimation based on measurement. Returns the new estimated position of
+    // the object x.
+    //
+    // Since the predict is trivial in our model, we run predict as a part of the update.
+    // Predict:
+    //   Calculate xPred (which is the same as x, so no op), and pPred
+    // Update:
+    //   Update K based on pPred, then apply it to calculate a new x and a new p.
+    // </summary>
     public Vector3 Update(Vector3 measurement) {
       var pPred = _p + _q;
       _k = pPred / (pPred + _r);
@@ -48,6 +58,12 @@ namespace SeedUnityVRKit {
       return _x = _x + (measurement - _x) * _k;
     }
 
+    // <summary>
+    // Updates the internal estimation based on measurement. Returns the new estimated position of
+    // the object x.
+    //
+    // This is the same as Update except also accepting a new measurement variance.
+    // </summary>
     public Vector3 Update(Vector3 measurement, float r) {
       _r = r;
       return Update(measurement);

--- a/Assets/Scripts/Animator/KalmanFilter.cs
+++ b/Assets/Scripts/Animator/KalmanFilter.cs
@@ -16,7 +16,7 @@ namespace SeedUnityVRKit {
     private readonly float _q;
     // Variance of how confident the measurement is. The larger this value, the less confident the
     // measurement is.
-    private readonly float _r;
+    private float _r;
     // Variance of how confident the current estimation is.
     // Predict:
     //   pPred = p + q
@@ -46,6 +46,11 @@ namespace SeedUnityVRKit {
       _k = pPred / (pPred + _r);
       _p = (1 - _k) * pPred;
       return _x = _x + (measurement - _x) * _k;
+    }
+
+    public Vector3 Update(Vector3 measurement, float r) {
+      _r = r;
+      return Update(measurement);
     }
   }
 }

--- a/Assets/Scripts/Animator/KalmanFilter.cs
+++ b/Assets/Scripts/Animator/KalmanFilter.cs
@@ -29,7 +29,7 @@ namespace SeedUnityVRKit {
     // measurement. Kalman gain is 0 means the estimated state is correct. Kalman gain is 1 means
     // the measured value (observation) is correct. It can be updated using prediction errors from
     // last state.
-    // g_k = p_(k-1) / (p_(k-1) + r)
+    // g_k = (p_(k-1) + q) / (p_(k-1) + q + r)
     private float _k;
 
     public KalmanFilter(float q, float r) {

--- a/Assets/Scripts/Animator/KalmanFilter.cs
+++ b/Assets/Scripts/Animator/KalmanFilter.cs
@@ -47,11 +47,5 @@ namespace SeedUnityVRKit {
       _p = (1 - _k) * pPred;
       return _x = _x + (measurement - _x) * _k;
     }
-
-    public void Reset() {
-      _p = 1;
-      _x = Vector3.zero;
-      _k = 0;
-    }
   }
 }

--- a/Assets/Scripts/Animator/KalmanFilter.cs
+++ b/Assets/Scripts/Animator/KalmanFilter.cs
@@ -4,12 +4,32 @@ using UnityEngine;
 namespace SeedUnityVRKit {
   // <summary>
   // Kalman filter implementation for <c>Vector3</c>.
+  //
+  // A good interactive tutorial for beginners about Kalman filter is
+  // https://simondlevy.academic.wlu.edu/kalman-tutorial/.
+  //
+  // This is a scalar version, only models one variable (position).
   // </summary>
   public class KalmanFilter {
+    // Process noise models noise to an "ideal" estimated state transition. The larger the
+    // value, the less accurate the new estimation is based on law of physics.
     private readonly float _q;
+    // Measure noise models noise in the measurement process. The larger the value is, the
+    // less accurate the measure is.
     private readonly float _r;
+    // Prediction error is used to update the Kalman gain. It is recursively updated from its
+    // last value with Kalman gain.
+    // p_k = (1 – g_k) * p_(k−1)
     private float _p = 0.1f;
+    // Prediction is recursively updated with
+    // x_k = x_(k-1) + g_k * (z_k - x_(k-1))
+    // It presents the most likely position of the object at given observation.
     private Vector3 _x;
+    // The Kalman gain is used to trade-off between estimated state from last time and current
+    // measurement. Kalman gain is 0 means the estimated state is correct. Kalman gain is 1 means
+    // the measured value (observation) is correct. It can be updated using prediction errors from
+    // last state.
+    // g_k = p_(k-1) / (p_(k-1) + r)
     private float _k;
 
     public KalmanFilter(float q, float r) {


### PR DESCRIPTION
- Add documentation on how the internal states are computed
- Refactor Update method for better alignment to the computation process, and also improve readability
- Remove unused Reset() method
- Add a new Update method which also takes a measurement variance. This is helpful to incorporate the `visibility` from Mediapipe landmark output in the future, indicating how confidence the measurement is. https://google.github.io/mediapipe/solutions/pose.html#pose_landmarks

This is a pure refactor. No behavioral changes.